### PR TITLE
feat(admin): apply sidebar and persist auth session

### DIFF
--- a/src/app/admin/_components/admin-header.tsx
+++ b/src/app/admin/_components/admin-header.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+// External libs
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+// Services
+import { useAuth } from "@/app/services/auth";
+
+// Utils/Helpers
+import { Button } from "@/components/ui/button";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+const AdminHeader = () => {
+  const { logout } = useAuth();
+  const router = useRouter();
+
+  const handleLogout = async (): Promise<void> => {
+    await logout();
+    router.push("/login");
+  };
+
+  return (
+    <header className="flex items-center justify-between border-b p-4">
+      <div className="flex items-center gap-4">
+        <SidebarTrigger className="md:hidden" />
+        <Link href="/admin" className="font-bold">
+          Admin
+        </Link>
+      </div>
+      <Button variant="outline" onClick={handleLogout}>
+        Sair
+      </Button>
+    </header>
+  );
+};
+
+export default AdminHeader;
+

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,41 +1,39 @@
 "use client";
 
 // External libs
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useEffect, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
 
-// Domain Entities/DTOs/Interfaces
-import type { ReactNode } from 'react';
-import { useAuth } from '@/app/services/auth';
+// Services
+import { useAuth } from "@/app/services/auth";
 
-// Utils/Helpers
-import { Button } from '@/components/ui/button';
+// Components
+import AdminHeader from "./_components/admin-header";
+import { AppSidebar } from "@/components/app-sidebar";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 
-const AdminLayout = ({
-  children,
-}: {
-  children: ReactNode;
-}) => {
-  const { logout } = useAuth();
+const AdminLayout = ({ children }: { children: ReactNode }) => {
+  const { user, loading } = useAuth();
   const router = useRouter();
 
-  const handleLogout = async (): Promise<void> => {
-    await logout();
-    router.push('/login');
-  };
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/login");
+    }
+  }, [user, loading, router]);
+
+  if (loading || !user) {
+    return null;
+  }
 
   return (
-    <div className="min-h-screen">
-      <header className="flex items-center justify-between border-b p-4">
-        <Link href="/admin" className="font-bold">
-          Admin
-        </Link>
-        <Button variant="outline" onClick={handleLogout}>
-          Sair
-        </Button>
-      </header>
-      <main className="p-4">{children}</main>
-    </div>
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <AdminHeader />
+        <main className="p-4">{children}</main>
+      </SidebarInset>
+    </SidebarProvider>
   );
 };
 

--- a/src/app/services/auth/index.tsx
+++ b/src/app/services/auth/index.tsx
@@ -5,6 +5,8 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import {
   createUserWithEmailAndPassword,
   onAuthStateChanged,
+  setPersistence,
+  browserLocalPersistence,
   signInWithEmailAndPassword,
   signOut,
   type User,
@@ -30,10 +32,13 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
+    setPersistence(firebaseAuth, browserLocalPersistence).catch(console.error);
+
     const unsubscribe = onAuthStateChanged(firebaseAuth, (firebaseUser) => {
       setUser(firebaseUser);
       setLoading(false);
     });
+
     return unsubscribe;
   }, []);
 


### PR DESCRIPTION
## Summary
- add sidebar layout to admin area
- persist Firebase auth session with local storage
- create reusable admin header component

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e5c267108325a92f26362a20797d