### PR TITLE
feat(clientes): add tabs to client detail

### DIFF
--- a/src/app/admin/clientes/[id]/_components/client-contracts.tsx
+++ b/src/app/admin/clientes/[id]/_components/client-contracts.tsx
@@ -1,0 +1,49 @@
+// Components
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+// Services
+import { type Contract } from "@/services/contracts/contracts.props";
+
+// DTOs
+interface ClientContractsProps {
+  contracts: Contract[];
+}
+
+const ClientContracts = ({ contracts }: ClientContractsProps) => {
+  return (
+    <Card>
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Título</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {contracts.map((contract) => (
+              <TableRow key={contract.id} className="odd:bg-muted/50">
+                <TableCell>{contract.title}</TableCell>
+              </TableRow>
+            ))}
+            {contracts.length === 0 ? (
+              <TableRow>
+                <TableCell>Nenhum contrato vinculado</TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ClientContracts;
+

--- a/src/app/admin/clientes/[id]/_components/client-documents.tsx
+++ b/src/app/admin/clientes/[id]/_components/client-documents.tsx
@@ -1,0 +1,15 @@
+// Components
+import { Card, CardContent } from "@/components/ui/card";
+
+const ClientDocuments = () => {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <p>Nenhum documento vinculado</p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ClientDocuments;
+

--- a/src/app/admin/clientes/[id]/_components/client-processes.tsx
+++ b/src/app/admin/clientes/[id]/_components/client-processes.tsx
@@ -1,0 +1,15 @@
+// Components
+import { Card, CardContent } from "@/components/ui/card";
+
+const ClientProcesses = () => {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <p>Nenhum processo vinculado</p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ClientProcesses;
+

--- a/src/app/admin/clientes/[id]/_components/client-profile.tsx
+++ b/src/app/admin/clientes/[id]/_components/client-profile.tsx
@@ -1,0 +1,83 @@
+// Components
+import { Card, CardContent } from "@/components/ui/card";
+
+// Services
+import { type Client } from "@/services/clients/clients.props";
+
+// DTOs
+interface Contact {
+  id: string;
+  name: string;
+  email?: string;
+  phone?: string;
+}
+
+interface Address {
+  id: string;
+  street: string;
+  city?: string;
+  state?: string;
+  zipCode?: string;
+}
+
+interface ClientProfileProps {
+  client: Client & {
+    contacts?: Contact[];
+    addresses?: Address[];
+  };
+}
+
+const ClientProfile = ({ client }: ClientProfileProps) => {
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-4">
+        <div className="space-y-2">
+          <p>
+            <strong>Email:</strong> {client.email ?? "-"}
+          </p>
+          <p>
+            <strong>Telefone:</strong> {client.phone ?? "-"}
+          </p>
+          <p>
+            <strong>Website:</strong> {client.website ?? "-"}
+          </p>
+          <p>
+            <strong>Notas:</strong> {client.notes ?? "-"}
+          </p>
+        </div>
+        {client.contacts?.length ? (
+          <div className="space-y-2">
+            <h4 className="font-semibold">Contatos</h4>
+            <ul className="list-disc space-y-1 pl-4">
+              {client.contacts.map((contact) => (
+                <li key={contact.id}>
+                  {contact.name}
+                  {contact.email ? ` - ${contact.email}` : ""}
+                  {contact.phone ? ` - ${contact.phone}` : ""}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+        {client.addresses?.length ? (
+          <div className="space-y-2">
+            <h4 className="font-semibold">Endereços</h4>
+            <ul className="list-disc space-y-1 pl-4">
+              {client.addresses.map((address) => (
+                <li key={address.id}>
+                  {address.street}
+                  {address.city ? `, ${address.city}` : ""}
+                  {address.state ? ` - ${address.state}` : ""}
+                  {address.zipCode ? `, ${address.zipCode}` : ""}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ClientProfile;
+

--- a/src/app/admin/clientes/[id]/page.tsx
+++ b/src/app/admin/clientes/[id]/page.tsx
@@ -17,15 +17,10 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
-import { Card, CardContent } from "@/components/ui/card";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import ClientProfile from "./_components/client-profile";
+import ClientContracts from "./_components/client-contracts";
+import ClientProcesses from "./_components/client-processes";
+import ClientDocuments from "./_components/client-documents";
 
 const ClienteViewPage = () => {
   const params = useParams<{ id: string }>();
@@ -48,53 +43,24 @@ const ClienteViewPage = () => {
           <Link href={`/admin/clientes/${clientId}/editar`}>Editar</Link>
         </Button>
       </PageHeader>
-      <Tabs defaultValue="details" className="space-y-4">
+      <Tabs defaultValue="profile" className="space-y-4">
         <TabsList>
-          <TabsTrigger value="details">Detalhes</TabsTrigger>
+          <TabsTrigger value="profile">Perfil do cliente</TabsTrigger>
           <TabsTrigger value="contracts">Contratos</TabsTrigger>
+          <TabsTrigger value="processes">Processos</TabsTrigger>
+          <TabsTrigger value="documents">Documentos</TabsTrigger>
         </TabsList>
-        <TabsContent value="details">
-          <Card>
-            <CardContent className="space-y-2 p-4">
-              <p>
-                <strong>Email:</strong> {client.email ?? "-"}
-              </p>
-              <p>
-                <strong>Telefone:</strong> {client.phone ?? "-"}
-              </p>
-              <p>
-                <strong>Website:</strong> {client.website ?? "-"}
-              </p>
-              <p>
-                <strong>Notas:</strong> {client.notes ?? "-"}
-              </p>
-            </CardContent>
-          </Card>
+        <TabsContent value="profile">
+          <ClientProfile client={client} />
         </TabsContent>
         <TabsContent value="contracts">
-          <Card>
-            <CardContent className="p-0">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Título</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {contracts.map((contract) => (
-                    <TableRow key={contract.id} className="odd:bg-muted/50">
-                      <TableCell>{contract.title}</TableCell>
-                    </TableRow>
-                  ))}
-                  {contracts.length === 0 ? (
-                    <TableRow>
-                      <TableCell>Nenhum contrato vinculado</TableCell>
-                    </TableRow>
-                  ) : null}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
+          <ClientContracts contracts={contracts} />
+        </TabsContent>
+        <TabsContent value="processes">
+          <ClientProcesses />
+        </TabsContent>
+        <TabsContent value="documents">
+          <ClientDocuments />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
## Summary
- add profile, contract, process and document tabs on client detail page
- split tab contents into dedicated components for maintainability

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab55e8daa483259ddc668c5cafc991