### PR TITLE
feat: add client contract management

### DIFF
--- a/src/app/admin/clientes/[id]/_components/client-contracts/client-contracts-props.ts
+++ b/src/app/admin/clientes/[id]/_components/client-contracts/client-contracts-props.ts
@@ -4,5 +4,7 @@ import { type Contract } from "@/services/contracts/contracts.props";
 // DTOs
 export interface ClientContractsProps {
   contracts: Contract[];
+  clientId: string;
+  organizationId: string;
 }
 

--- a/src/app/admin/clientes/[id]/_components/client-contracts/contract-form-props.ts
+++ b/src/app/admin/clientes/[id]/_components/client-contracts/contract-form-props.ts
@@ -1,0 +1,17 @@
+// External libs
+import { z } from "zod";
+
+// DTOs
+export const contractFormSchema = z.object({
+  title: z.string().min(1, "Título é obrigatório"),
+  file: z
+    .any()
+    .refine((file) => file instanceof File, "Arquivo é obrigatório"),
+});
+
+export type ContractFormSchema = z.infer<typeof contractFormSchema>;
+
+export interface ContractFormProps {
+  onSubmit: (values: ContractFormSchema) => Promise<void>;
+  loading?: boolean;
+}

--- a/src/app/admin/clientes/[id]/_components/client-contracts/contract-form.tsx
+++ b/src/app/admin/clientes/[id]/_components/client-contracts/contract-form.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+// External libs
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+// Components
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+// DTOs
+import {
+  contractFormSchema,
+  type ContractFormProps,
+  type ContractFormSchema,
+} from "./contract-form-props";
+
+const ContractForm = ({ onSubmit, loading }: ContractFormProps) => {
+  const form = useForm<ContractFormSchema>({
+    resolver: zodResolver(contractFormSchema),
+    defaultValues: { title: "" },
+  });
+
+  const submit = async (values: ContractFormSchema) => {
+    await onSubmit(values);
+    form.reset();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(submit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Título</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="file"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Arquivo</FormLabel>
+              <FormControl>
+                <Input
+                  type="file"
+                  accept="application/pdf,image/*"
+                  onChange={(e) => field.onChange(e.target.files?.[0])}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full" disabled={loading}>
+          Salvar
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+export default ContractForm;

--- a/src/app/admin/clientes/[id]/_components/client-contracts/index.tsx
+++ b/src/app/admin/clientes/[id]/_components/client-contracts/index.tsx
@@ -1,44 +1,100 @@
+"use client";
+
+// External libs
+import { useState } from "react";
+import { File as FileIcon, FileImage, FileText, Plus } from "lucide-react";
+
+// Services
+import { useCreateContract } from "@/services/contracts";
+
 // Components
 import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import ContractForm from "./contract-form";
 
 // DTOs
 import type { ClientContractsProps } from "./client-contracts-props";
 
-const ClientContracts = ({ contracts }: ClientContractsProps) => {
+// Utils
+const getIcon = (ext?: string) => {
+  switch (ext) {
+    case "pdf":
+      return FileText;
+    case "png":
+    case "jpg":
+    case "jpeg":
+    case "gif":
+      return FileImage;
+    default:
+      return FileIcon;
+  }
+};
+
+const ClientContracts = ({
+  contracts,
+  clientId,
+  organizationId,
+}: ClientContractsProps) => {
+  const [open, setOpen] = useState(false);
+  const { mutateAsync: createContract, isPending } = useCreateContract(clientId);
+
+  const handleSubmit = async ({ title, file }: { title: string; file: File }) => {
+    await createContract({ title, organizationId, file });
+    setOpen(false);
+  };
+
   return (
     <Card>
-      <CardContent className="p-0">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Título</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {contracts.map((contract) => (
-              <TableRow key={contract.id} className="odd:bg-muted/50">
-                <TableCell>{contract.title}</TableCell>
-              </TableRow>
-            ))}
-            {contracts.length === 0 ? (
-              <TableRow>
-                <TableCell>Nenhum contrato vinculado</TableCell>
-              </TableRow>
-            ) : null}
-          </TableBody>
-        </Table>
+      <CardContent className="p-4 space-y-4">
+        <div className="flex justify-end">
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <Plus className="mr-2 size-4" />
+                Adicionar contrato
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Novo contrato</DialogTitle>
+              </DialogHeader>
+              <ContractForm onSubmit={handleSubmit} loading={isPending} />
+            </DialogContent>
+          </Dialog>
+        </div>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 md:grid-cols-6">
+          {contracts.map((contract) => {
+            const Icon = getIcon(contract.file?.extension);
+            return (
+              <div
+                key={contract.id}
+                className="flex flex-col items-center text-center"
+              >
+                <div className="bg-muted rounded-md p-4 transition hover:shadow-md">
+                  <Icon className="size-10 text-primary" />
+                </div>
+                <span className="mt-2 w-full truncate text-sm">
+                  {contract.file?.name ?? contract.title}
+                </span>
+              </div>
+            );
+          })}
+          {contracts.length === 0 ? (
+            <p className="col-span-full text-center text-sm text-muted-foreground">
+              Nenhum contrato vinculado
+            </p>
+          ) : null}
+        </div>
       </CardContent>
     </Card>
   );
 };
 
 export default ClientContracts;
-

--- a/src/app/admin/clientes/[id]/page.tsx
+++ b/src/app/admin/clientes/[id]/page.tsx
@@ -60,7 +60,13 @@ const ClienteViewPage = () => {
           )}
         </TabsContent>
         <TabsContent value="contracts">
-          <ClientContracts contracts={contracts} />
+          {client ? (
+            <ClientContracts
+              contracts={contracts}
+              clientId={clientId}
+              organizationId={client.organizationId}
+            />
+          ) : null}
         </TabsContent>
         <TabsContent value="processes">
           <ClientProcesses />

--- a/src/services/contracts/contracts.props.ts
+++ b/src/services/contracts/contracts.props.ts
@@ -1,7 +1,21 @@
 // DTOs
+export interface ContractFile {
+  id: string;
+  name: string;
+  extension: string;
+  url?: string;
+}
+
 export interface Contract {
   id: string;
   title: string;
+  clientId?: string;
+  file?: ContractFile;
+}
+
+export interface CreateContractDto {
+  title: string;
+  organizationId: string;
   clientId?: string;
 }
 

--- a/src/services/contracts/contracts.query.ts
+++ b/src/services/contracts/contracts.query.ts
@@ -1,11 +1,19 @@
 // External libs
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 // Services
-import { listContracts } from './contracts.service';
+import {
+  listContracts,
+  createContract,
+  uploadContractFile,
+  updateContractFile,
+} from './contracts.service';
 
 // DTOs
-import { type Contract, type ContractQueryDto } from './contracts.props';
+import {
+  type Contract,
+  type ContractQueryDto,
+} from './contracts.props';
 
 export const useListContracts = (query: ContractQueryDto) =>
   useQuery<Contract[]>({
@@ -13,3 +21,22 @@ export const useListContracts = (query: ContractQueryDto) =>
     queryFn: () => listContracts(query),
     enabled: Object.values(query).some(Boolean),
   });
+
+export const useCreateContract = (clientId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: { title: string; organizationId: string; file: File }) => {
+      const contract = await createContract({
+        title: data.title,
+        organizationId: data.organizationId,
+        clientId,
+      });
+      const fileId = await uploadContractFile(clientId, data.file);
+      await updateContractFile(contract.id, fileId);
+      return contract;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['contracts', { clientId }] });
+    },
+  });
+};

--- a/src/services/contracts/contracts.service.ts
+++ b/src/services/contracts/contracts.service.ts
@@ -1,5 +1,9 @@
 // Services
-import { type Contract, type ContractQueryDto } from "./contracts.props";
+import {
+  type Contract,
+  type ContractQueryDto,
+  type CreateContractDto,
+} from "./contracts.props";
 
 const API_BASE_URL = process.env.API_BASE_URL ?? "";
 const buildUrl = (path: string) => `${API_BASE_URL}${path}`;
@@ -14,11 +18,95 @@ export const listContracts = async (
     }
   });
 
-  const res = await fetch(url.toString(), { cache: "no-store" });
+  const res = await fetch(url.toString(), {
+    cache: "no-store",
+    credentials: "include",
+  });
 
   if (!res.ok) {
     throw new Error("Failed to list contracts");
   }
 
   return res.json();
+};
+
+export const createContract = async (
+  data: CreateContractDto,
+): Promise<Contract> => {
+  const res = await fetch(buildUrl("/api/v1/contracts"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to create contract");
+  }
+
+  return res.json();
+};
+
+export const uploadContractFile = async (
+  clientId: string,
+  file: File,
+): Promise<string> => {
+  const key = `${clientId}/contratos/${file.name}`;
+
+  const presignRes = await fetch(buildUrl("/api/v1/s3/presign"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, contentType: file.type }),
+    credentials: "include",
+  });
+
+  if (!presignRes.ok) {
+    throw new Error("Failed to generate presigned URL");
+  }
+
+  const { url } = await presignRes.json();
+
+  const uploadRes = await fetch(url, {
+    method: "PUT",
+    body: file,
+  });
+
+  if (!uploadRes.ok) {
+    throw new Error("Failed to upload file");
+  }
+
+  const completeRes = await fetch(buildUrl("/api/v1/s3/complete-upload"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      file: key,
+      name: file.name,
+      extension: file.name.split(".").pop(),
+      folder: `${clientId}/contratos`,
+    }),
+    credentials: "include",
+  });
+
+  if (!completeRes.ok) {
+    throw new Error("Failed to complete upload");
+  }
+
+  const { id } = await completeRes.json();
+  return id as string;
+};
+
+export const updateContractFile = async (
+  id: string,
+  fileId: string,
+): Promise<void> => {
+  const res = await fetch(buildUrl(`/api/v1/contracts/${id}/file`), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fileId }),
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to update contract file");
+  }
 };


### PR DESCRIPTION
## Summary
- allow uploading and attaching contract files to a client
- show contracts in a document-style grid
- add services for creating contracts and uploading files to S3

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab6617019883258e4fae4fb6ba0e8c