### PR TITLE
feat: simplify contract file upload

### DIFF
--- a/src/services/contracts/contracts.props.ts
+++ b/src/services/contracts/contracts.props.ts
@@ -13,11 +13,20 @@ export interface Contract {
   file?: ContractFile;
 }
 
+export interface S3UploadResponse {
+  key: string;
+  url: string;
+  eTag: string;
+}
+
 export interface CreateContractDto {
   title: string;
   organizationId: string;
   clientId?: string;
-  fileId?: string;
+  file: S3UploadResponse & {
+    name: string;
+    extension: string;
+  };
 }
 
 export interface ContractQueryDto {

--- a/src/services/contracts/contracts.query.ts
+++ b/src/services/contracts/contracts.query.ts
@@ -25,12 +25,17 @@ export const useCreateContract = (clientId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (data: { title: string; organizationId: string; file: File }) => {
-      const fileId = await uploadContractFile(clientId, data.file);
+      const uploaded = await uploadContractFile(clientId, data.file);
+      const extension = data.file.name.split('.')?.pop() ?? '';
       const contract = await createContract({
         title: data.title,
         organizationId: data.organizationId,
         clientId,
-        fileId,
+        file: {
+          ...uploaded,
+          name: data.file.name,
+          extension,
+        },
       });
       return contract;
     },

--- a/src/services/contracts/contracts.service.ts
+++ b/src/services/contracts/contracts.service.ts
@@ -3,6 +3,7 @@ import {
   type Contract,
   type ContractQueryDto,
   type CreateContractDto,
+  type S3UploadResponse,
 } from "./contracts.props";
 
 const API_BASE_URL = process.env.API_BASE_URL ?? "";
@@ -50,61 +51,22 @@ export const createContract = async (
 export const uploadContractFile = async (
   clientId: string,
   file: File,
-): Promise<string> => {
-  const folder = `${clientId}/contratos`;
-  const key = `${folder}/${file.name}`;
-  const extension = file.name.split(".").pop() ?? "";
+): Promise<S3UploadResponse> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("folder", `${clientId}/contrato`);
 
-  const presignRes = await fetch(buildUrl("/api/v1/s3/presign"), {
+  const res = await fetch(buildUrl("/api/v1/s3/upload"), {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ key, contentType: file.type }),
+    body: formData,
     credentials: "include",
   });
 
-  if (!presignRes.ok) {
-    throw new Error("Failed to generate presigned URL");
+  if (!res.ok) {
+    throw new Error("Failed to upload contract file");
   }
 
-  const { url } = await presignRes.json();
-  const rawUrl = (url as string).split("?")[0];
-  const baseUrl = rawUrl.replace(`/${key}`, "");
-
-  const uploadRes = await fetch(url, {
-    method: "PUT",
-    headers: { "Content-Type": file.type },
-    body: file,
-  });
-
-  if (!uploadRes.ok) {
-    throw new Error("Failed to upload file");
-  }
-
-  const eTag = uploadRes.headers.get("ETag")?.replace(/"/g, "");
-
-  const completeRes = await fetch(buildUrl("/api/v1/s3/complete-upload"), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      name: file.name,
-      extension,
-      baseUrl,
-      folder,
-      file: key,
-      url: rawUrl,
-      size: file.size,
-      contentType: file.type,
-      eTag,
-    }),
-    credentials: "include",
-  });
-
-  if (!completeRes.ok) {
-    throw new Error("Failed to complete upload");
-  }
-
-  const { id } = await completeRes.json();
-  return id as string;
+  return res.json();
 };
 
 export const updateContractFile = async (


### PR DESCRIPTION
## Summary
- refactor contract file upload to use S3 upload endpoint and client-specific folder
- include upload metadata when creating contracts

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font `Montserrat`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab705027c48325ac9dc15c9e3fb7c7