### PR TITLE
feat: upload contract on file change and restyle client form

### DIFF
--- a/src/app/admin/clientes/[id]/_components/client-contracts/client-contracts-props.ts
+++ b/src/app/admin/clientes/[id]/_components/client-contracts/client-contracts-props.ts
@@ -5,6 +5,5 @@ import { type Contract } from "@/services/contracts/contracts.props";
 export interface ClientContractsProps {
   contracts: Contract[];
   clientId: string;
-  organizationId: string;
 }
 

--- a/src/app/admin/clientes/[id]/_components/client-contracts/contract-form-props.ts
+++ b/src/app/admin/clientes/[id]/_components/client-contracts/contract-form-props.ts
@@ -4,9 +4,7 @@ import { z } from "zod";
 // DTOs
 export const contractFormSchema = z.object({
   title: z.string().min(1, "Título é obrigatório"),
-  file: z
-    .any()
-    .refine((file) => file instanceof File, "Arquivo é obrigatório"),
+  fileId: z.string().min(1, "Arquivo é obrigatório"),
 });
 
 export type ContractFormSchema = z.infer<typeof contractFormSchema>;

--- a/src/app/admin/clientes/[id]/_components/client-contracts/index.tsx
+++ b/src/app/admin/clientes/[id]/_components/client-contracts/index.tsx
@@ -37,16 +37,18 @@ const getIcon = (ext?: string) => {
   }
 };
 
-const ClientContracts = ({
-  contracts,
-  clientId,
-  organizationId,
-}: ClientContractsProps) => {
+const ClientContracts = ({ contracts, clientId }: ClientContractsProps) => {
   const [open, setOpen] = useState(false);
   const { mutateAsync: createContract, isPending } = useCreateContract(clientId);
 
-  const handleSubmit = async ({ title, file }: { title: string; file: File }) => {
-    await createContract({ title, organizationId, file });
+  const handleSubmit = async ({
+    title,
+    fileId,
+  }: {
+    title: string;
+    fileId: string;
+  }) => {
+    await createContract({ title, fileId });
     setOpen(false);
   };
 

--- a/src/app/admin/clientes/[id]/page.tsx
+++ b/src/app/admin/clientes/[id]/page.tsx
@@ -61,11 +61,7 @@ const ClienteViewPage = () => {
         </TabsContent>
         <TabsContent value="contracts">
           {client ? (
-            <ClientContracts
-              contracts={contracts}
-              clientId={clientId}
-              organizationId={client.organizationId}
-            />
+            <ClientContracts contracts={contracts} clientId={clientId} />
           ) : null}
         </TabsContent>
         <TabsContent value="processes" className="pt-4">

--- a/src/app/admin/clientes/_components/client-form/index.tsx
+++ b/src/app/admin/clientes/_components/client-form/index.tsx
@@ -81,6 +81,12 @@ const ClientForm = ({
   };
 
   const personType = form.watch("personType");
+  const fieldStyles =
+    "bg-white px-3 pt-2.5 pb-1.5 outline-1 -outline-offset-1 outline-gray-300 focus-within:relative focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600 dark:bg-white/5 dark:outline-gray-700 dark:focus-within:outline-indigo-500";
+  const inputStyles =
+    "block w-full text-gray-900 placeholder:text-gray-400 focus:outline-none sm:text-sm/6 dark:bg-transparent dark:text-white dark:placeholder:text-gray-500";
+  const labelStyles =
+    "block text-xs font-medium text-gray-900 dark:text-gray-200";
 
   return (
     <Form {...form}>
@@ -90,15 +96,15 @@ const ClientForm = ({
       >
         <div className="flex-1 space-y-4">
           {personType === "PF" ? (
-            <>
+            <div className="-space-y-px">
               <FormField
                 control={form.control}
                 name="fullName"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Nome completo</FormLabel>
+                  <FormItem className={`rounded-t-md ${fieldStyles}`}>
+                    <FormLabel className={labelStyles}>Nome completo</FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <Input {...field} className={inputStyles} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -108,26 +114,30 @@ const ClientForm = ({
                 control={form.control}
                 name="cpf"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>CPF</FormLabel>
+                  <FormItem className={`rounded-b-md ${fieldStyles}`}>
+                    <FormLabel className={labelStyles}>CPF</FormLabel>
                     <FormControl>
-                      <MaskedInput mask={maskCpf} {...field} />
+                      <MaskedInput
+                        mask={maskCpf}
+                        {...field}
+                        className={inputStyles}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-            </>
+            </div>
           ) : (
-            <>
+            <div className="-space-y-px">
               <FormField
                 control={form.control}
                 name="companyName"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Razão social</FormLabel>
+                  <FormItem className={`rounded-t-md ${fieldStyles}`}>
+                    <FormLabel className={labelStyles}>Razão social</FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <Input {...field} className={inputStyles} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -137,95 +147,115 @@ const ClientForm = ({
                 control={form.control}
                 name="cnpj"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>CNPJ</FormLabel>
+                  <FormItem className={`rounded-b-md ${fieldStyles}`}>
+                    <FormLabel className={labelStyles}>CNPJ</FormLabel>
                     <FormControl>
-                      <MaskedInput mask={maskCnpj} {...field} />
+                      <MaskedInput
+                        mask={maskCnpj}
+                        {...field}
+                        className={inputStyles}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-            </>
+            </div>
           )}
-          <FormField
-            control={form.control}
-            name="email"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Email</FormLabel>
-                <FormControl>
-                  <Input type="email" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="phone"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Telefone</FormLabel>
-                <FormControl>
-                  <MaskedInput mask={maskPhone} {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="website"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Website</FormLabel>
-                <FormControl>
-                  <Input {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="notes"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Notas</FormLabel>
-                <FormControl>
-                  <Textarea {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="logoFileId"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Logo</FormLabel>
-                <FormControl>
-                  <Input
-                    type="file"
-                    disabled={uploading}
-                    onChange={(e) => handleFileChange(e, field)}
-                  />
-                </FormControl>
-                {uploading ? (
-                  <p className="text-muted-foreground mt-1 flex items-center gap-1 text-xs">
-                    <Loader2 className="size-3 animate-spin" /> Enviando...
-                  </p>
-                ) : field.value ? (
-                  <p className="text-muted-foreground mt-1 text-xs">
-                    Arquivo enviado
-                  </p>
-                ) : null}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+
+          <div className="-space-y-px">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem className={`rounded-t-md ${fieldStyles}`}>
+                  <FormLabel className={labelStyles}>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      {...field}
+                      className={inputStyles}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="phone"
+              render={({ field }) => (
+                <FormItem className={`rounded-b-md ${fieldStyles}`}>
+                  <FormLabel className={labelStyles}>Telefone</FormLabel>
+                  <FormControl>
+                    <MaskedInput
+                      mask={maskPhone}
+                      {...field}
+                      className={inputStyles}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="-space-y-px">
+            <FormField
+              control={form.control}
+              name="website"
+              render={({ field }) => (
+                <FormItem className={`rounded-t-md ${fieldStyles}`}>
+                  <FormLabel className={labelStyles}>Website</FormLabel>
+                  <FormControl>
+                    <Input {...field} className={inputStyles} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem className={`rounded-b-md ${fieldStyles}`}>
+                  <FormLabel className={labelStyles}>Notas</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} className={inputStyles} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="-space-y-px">
+            <FormField
+              control={form.control}
+              name="logoFileId"
+              render={({ field }) => (
+                <FormItem className={`rounded-md ${fieldStyles}`}>
+                  <FormLabel className={labelStyles}>Logo</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="file"
+                      disabled={uploading}
+                      onChange={(e) => handleFileChange(e, field)}
+                      className={inputStyles}
+                    />
+                  </FormControl>
+                  {uploading ? (
+                    <p className="text-muted-foreground mt-1 flex items-center gap-1 text-xs">
+                      <Loader2 className="size-3 animate-spin" /> Enviando...
+                    </p>
+                  ) : field.value ? (
+                    <p className="text-muted-foreground mt-1 text-xs">Arquivo enviado</p>
+                  ) : null}
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
         </div>
         <div className="bg-background sticky bottom-0 pt-4">
           <Button

--- a/src/services/contracts/contracts.props.ts
+++ b/src/services/contracts/contracts.props.ts
@@ -14,28 +14,12 @@ export interface Contract {
   file?: ContractFile;
 }
 
-export interface S3UploadResponse {
-  key: string;
-  url: string;
-  eTag: string;
+export interface ContractQueryDto {
+  clientId?: string;
 }
 
 export interface CreateContractDto {
   title: string;
-  organizationId: string;
-  clientId?: string;
-  file: S3UploadResponse & {
-    name: string;
-    extension: string;
-  };
-}
-
-export interface LinkContractDto {
-  title: string;
   fileId: string;
   clientId: string;
-}
-
-export interface ContractQueryDto {
-  clientId?: string;
 }

--- a/src/services/contracts/contracts.query.ts
+++ b/src/services/contracts/contracts.query.ts
@@ -2,12 +2,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 // Services
-import {
-  listContracts,
-  createContract,
-  uploadContractFile,
-  linkContractToClient,
-} from './contracts.service';
+import { listContracts, createContract } from './contracts.service';
 
 // DTOs
 import {
@@ -25,32 +20,8 @@ export const useListContracts = (query: ContractQueryDto) =>
 export const useCreateContract = (clientId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (data: { title: string; organizationId: string; file: File }) => {
-      const uploaded = await uploadContractFile(clientId, data.file);
-      const extension = data.file.name.split('.')?.pop() ?? '';
-      const contract = await createContract({
-        title: data.title,
-        organizationId: data.organizationId,
-        clientId,
-        file: {
-          ...uploaded,
-          name: data.file.name,
-          extension,
-        },
-      });
-      return contract;
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['contracts', { clientId }] });
-    },
-  });
-};
-
-export const useLinkContract = (clientId: string) => {
-  const queryClient = useQueryClient();
-  return useMutation({
     mutationFn: (data: { title: string; fileId: string }) =>
-      linkContractToClient({ ...data, clientId }),
+      createContract({ ...data, clientId }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['contracts', { clientId }] });
     },

--- a/src/services/contracts/contracts.service.ts
+++ b/src/services/contracts/contracts.service.ts
@@ -3,8 +3,6 @@ import {
   type Contract,
   type ContractQueryDto,
   type CreateContractDto,
-  type LinkContractDto,
-  type S3UploadResponse,
 } from "./contracts.props";
 
 const API_BASE_URL = process.env.API_BASE_URL ?? "";
@@ -44,60 +42,6 @@ export const createContract = async (
 
   if (!res.ok) {
     throw new Error("Failed to create contract");
-  }
-
-  return res.json();
-};
-
-export const uploadContractFile = async (
-  clientId: string,
-  file: File,
-): Promise<S3UploadResponse> => {
-  const formData = new FormData();
-  formData.append("file", file);
-  formData.append("folder", `${clientId}/contrato`);
-
-  const res = await fetch(buildUrl("/api/v1/s3/upload"), {
-    method: "POST",
-    body: formData,
-    credentials: "include",
-  });
-
-  if (!res.ok) {
-    throw new Error("Failed to upload contract file");
-  }
-
-  return res.json();
-};
-
-export const updateContractFile = async (
-  id: string,
-  fileId: string,
-): Promise<void> => {
-  const res = await fetch(buildUrl(`/api/v1/contracts/${id}/file`), {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ fileId }),
-    credentials: "include",
-  });
-
-  if (!res.ok) {
-    throw new Error("Failed to update contract file");
-  }
-};
-
-export const linkContractToClient = async (
-  data: LinkContractDto,
-): Promise<Contract> => {
-  const res = await fetch(buildUrl("/api/v1/client-contracts"), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-    credentials: "include",
-  });
-
-  if (!res.ok) {
-    throw new Error("Failed to link contract to client");
   }
 
   return res.json();


### PR DESCRIPTION
## Summary
- upload contract file on selection with loading state
- simplify contracts API to accept fileId and link to client
- restyle client creation form using grouped field design

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab7b1a81a88325a0ffe7cde429b354