### PR TITLE
feat: enable contract file upload

### DIFF
--- a/src/app/admin/clientes/[id]/_components/client-contracts/contract-form.tsx
+++ b/src/app/admin/clientes/[id]/_components/client-contracts/contract-form.tsx
@@ -43,7 +43,7 @@ const ContractForm = ({ onSubmit, loading }: ContractFormProps) => {
     if (file) {
       setUploading(true);
       try {
-        const { id } = await uploadFile(file);
+        const { id } = await uploadFile(file, "contracts");
         field.onChange(id);
       } catch (error) {
         console.error(error);

--- a/src/services/files/files.props.ts
+++ b/src/services/files/files.props.ts
@@ -1,4 +1,15 @@
 // DTOs
 export interface FileUploadResponse {
   id: string;
+  name: string;
+  extension: string;
+  baseUrl: string;
+  folder: string;
+  file: string;
+  url: string;
+  size: number;
+  contentType: string;
+  eTag: string;
+  createdAt: string;
+  updatedAt: string;
 }

--- a/src/services/files/files.service.ts
+++ b/src/services/files/files.service.ts
@@ -3,11 +3,17 @@ import type { FileUploadResponse } from "./files.props";
 
 const API_BASE_URL = process.env.API_BASE_URL ?? "";
 
-export const uploadFile = async (file: File): Promise<FileUploadResponse> => {
+export const uploadFile = async (
+  file: File,
+  folder?: string,
+): Promise<FileUploadResponse> => {
   const formData = new FormData();
+  if (folder) {
+    formData.append("folder", folder);
+  }
   formData.append("file", file);
 
-  const res = await fetch(`${API_BASE_URL}/api/v1/files`, {
+  const res = await fetch(`${API_BASE_URL}/api/v1/s3/upload`, {
     method: "POST",
     body: formData,
   });


### PR DESCRIPTION
## Summary
- expand file upload response to include metadata
- support folder uploads to S3 and use for contract documents

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab8101e40c8325bfba38facc98d3c2